### PR TITLE
Makefile::AST::Evaluator: remove strange unicode char

### DIFF
--- a/lib/Makefile/AST/Evaluator.pm
+++ b/lib/Makefile/AST/Evaluator.pm
@@ -335,7 +335,7 @@ This variable corresponds to GNU make's command line option C<-n>, C<--just-prin
 
 =item C<$IgnoreErrors>
 
-This variable corresponds to GNU make's command line option C<-i> or C<--ignore-errors>，It's used to ignore the errors of shell commands being executed during the make process. The default behavior is quitting as soon as a shell command without the C<-> modifier fails.
+This variable corresponds to GNU make's command line option C<-i> or C<--ignore-errors>. It's used to ignore the errors of shell commands being executed during the make process. The default behavior is quitting as soon as a shell command without the C<-> modifier fails.
 
 =back
 


### PR DESCRIPTION
This was causing test failures in pod.t since the pod doesn't declare encoding (thus defaulting to ascii).

```
t/99-pod.t ........... 1/13
#   Failed test 'POD test for blib/lib/Makefile/AST/Evaluator.pm'
#   at /usr/share/perl5/Test/Pod.pm line 186.
Wide character in print at /home/olof/src/github/agentzh/makefile-parser-pm/inc/Test/Builder.pm line 1471.
# blib/lib/Makefile/AST/Evaluator.pm (338): Non-ASCII character seen before =encoding in 'C<--ignore-errors>，It's'. Assuming UTF-8
# Looks like you failed 1 test of 13.
t/99-pod.t ........... Dubious, test returned 1 (wstat 256, 0x100)
```

I don't know if the choice was intentional, but I _guess_ not; it does look a lot like a ,.
